### PR TITLE
p3 rules: removed "buildings" references for "fortifications" (#12)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,5 +1,5 @@
 ---
-name: 📓 Feedback on ASCII Planets
+name: 🌎 Feedback on ASCII Planets
 about: Provide feedback about gameplay, rules, adjustments, or anything else that will improve the game
 ---
 ##### Version of rulebook and Planet Sheet

--- a/planet_sheet/technology.tex
+++ b/planet_sheet/technology.tex
@@ -59,22 +59,22 @@
   \textbf{/} &
   \multicolumn{1}{c|}{} &
   \multicolumn{1}{c|}{} &
-  \multicolumn{1}{c|}{0} &
+  \multicolumn{1}{c|}{S} &
   \multicolumn{1}{c|}{} &
   \multicolumn{1}{c|}{} &
   \multicolumn{1}{c|}{} &
-  \multicolumn{1}{c|}{0} &
+  \multicolumn{1}{c|}{S} &
   \multicolumn{1}{c|}{} &
-  \multicolumn{1}{c|}{\cellcolor{engineeringlight}0} &
+  \multicolumn{1}{c|}{\cellcolor{engineeringlight}S} &
   \multicolumn{1}{c|}{\cellcolor{engineeringlight}{\color{engineeringlight} C}} &
   \multicolumn{1}{c|}{\cellcolor{engineeringlight}{\color{engineeringlight} C}} &
-  \multicolumn{1}{c|}{\cellcolor{engineeringlight}0} &
+  \multicolumn{1}{c|}{\cellcolor{engineeringlight}S} &
   \multicolumn{1}{c|}{\cellcolor{engineeringlight}{\color{engineeringlight} C}} &
   \multicolumn{1}{c|}{\cellcolor{engineeringlight}{\color{engineeringlight} C}} &
-  \multicolumn{1}{c|}{\cellcolor{engineeringlight}0} &
+  \multicolumn{1}{c|}{\cellcolor{engineeringlight}S} &
   \multicolumn{1}{c|}{\cellcolor{engineeringlight}{\color{engineeringlight} C}} &
   \multicolumn{1}{c|}{\cellcolor{engineeringlight}{\color{engineeringlight} C}} &
-  \multicolumn{1}{c|}{\cellcolor{engineeringlight}0} &
+  \multicolumn{1}{c|}{\cellcolor{engineeringlight}S} &
   \multicolumn{1}{c|}{\cellcolor{engineeringlight}\textbf{!}} \\ \cline{5-22}
  &
   \multicolumn{5}{l}{{[}{]} Cure} &
@@ -97,7 +97,7 @@
 \multicolumn{6}{l}{{\color{engineeringlight} Immune to Pandemic}} &
   \multicolumn{4}{l}{{[}{]} Warp drive} &
   \multicolumn{1}{c|}{} &
-  \multicolumn{1}{c|}{0} &
+  \multicolumn{1}{c|}{S} &
   \multicolumn{1}{c|}{} &
   \multicolumn{1}{c|}{} &
   \multicolumn{1}{c|}{} &

--- a/planet_sheet/trade.tex
+++ b/planet_sheet/trade.tex
@@ -22,9 +22,9 @@
   \multicolumn{1}{l|}{\cellcolor{trade}5+} &
   \multicolumn{1}{l|}{\cellcolor{trade}6+} &
   - &
-  \multicolumn{2}{l}{:) 000 S} &
+  \multicolumn{2}{l}{:) SSS T} &
    &
-  {\color{supplemental} 0} &
+  {\color{supplemental} S} &
    &
    &
    \\ \hhline{~~---}
@@ -34,9 +34,9 @@
   \multicolumn{1}{l|}{\cellcolor{trade}5+} &
   \multicolumn{1}{l|}{\cellcolor{trade}6+} &
   - &
-  \multicolumn{2}{l}{:) 000 SS} &
+  \multicolumn{2}{l}{:) SSS TT} &
    &
-  {\color{supplemental} 0S} &
+  {\color{supplemental} ST} &
    &
    &
    \\ \hhline{~----}
@@ -46,21 +46,9 @@
   \multicolumn{1}{l|}{\cellcolor{trade}5+} &
   \multicolumn{1}{l|}{\cellcolor{trade}6+} &
   - &
-  \multicolumn{2}{l}{:) 000 C} &
+  \multicolumn{2}{l}{:) SSS T} &
    &
-  {\color{supplemental} 0C} &
-   &
-   &
-   \\ \hhline{-----}
-\multicolumn{1}{|l|}{\cellcolor{trade}2+} &
-  \multicolumn{1}{l|}{\cellcolor{trade}3+} &
-  \multicolumn{1}{l|}{\cellcolor{trade}4+} &
-  \multicolumn{1}{l|}{\cellcolor{trade}5+} &
-  \multicolumn{1}{l|}{\cellcolor{trade}6+} &
-  - &
-  \multicolumn{2}{l}{:) 000 CC} &
-   &
-  {\color{supplemental} 0C} &
+  {\color{supplemental} SC} &
    &
    &
    \\ \hhline{-----}
@@ -70,9 +58,21 @@
   \multicolumn{1}{l|}{\cellcolor{trade}5+} &
   \multicolumn{1}{l|}{\cellcolor{trade}6+} &
   - &
-  \multicolumn{2}{l}{:) 000 CC} &
+  \multicolumn{2}{l}{:) SSS CC} &
    &
-  {\color{supplemental} 0C} &
+  {\color{supplemental} SC} &
+   &
+   &
+   \\ \hhline{-----}
+\multicolumn{1}{|l|}{\cellcolor{trade}2+} &
+  \multicolumn{1}{l|}{\cellcolor{trade}3+} &
+  \multicolumn{1}{l|}{\cellcolor{trade}4+} &
+  \multicolumn{1}{l|}{\cellcolor{trade}5+} &
+  \multicolumn{1}{l|}{\cellcolor{trade}6+} &
+  - &
+  \multicolumn{2}{l}{:) SSS CC} &
+   &
+  {\color{supplemental} SC} &
    &
    &
    \\ \hhline{-----}

--- a/rules/rules_conventions.tex
+++ b/rules/rules_conventions.tex
@@ -19,7 +19,7 @@
 \newcommand{\factorysymbol}{\texttt{F}}
 \newcommand{\labsymbol}{\texttt{L}}
 \newcommand{\starshipsymbol}{\texttt{*}}
-\newcommand{\battleshipsymbol}{\texttt{F}}
+\newcommand{\battleshipsymbol}{\texttt{B}}
 \newcommand{\spacestationsymbol}{\texttt{@}}
 \newcommand{\gainastronautsymbol}{\texttt{/}}
 \newcommand{\useastronautsymbol}{\texttt{X}}

--- a/rules/rules_dice.tex
+++ b/rules/rules_dice.tex
@@ -1,7 +1,7 @@
 % !TEX TS-program = XeLaTeX
 In the \development\ phase, players use the dice to improve their \planets. Each die can be assigned to one of the following actions:
 \begin{itemize}
-	\item \activating\ one building type
+	\item \activating\ one \fortification\ type
 	\item For \trade\ (see \nameref{sec:trade}, p.\pageref{sec:trade})
 	\item For \culture\ (see \nameref{sec:culture}, p.\pageref{sec:culture})
   \item Constructing \fortifications\ (see \nameref{sec:fortifications}, p.\pageref{sec:fortifications})

--- a/rules/rules_disasters.tex
+++ b/rules/rules_disasters.tex
@@ -10,7 +10,7 @@ Whenever the third (shaded) box of any row of the \disaster\ grid is checked, th
 \newline\newline
 Many \disasters\ only trigger under certain conditions and/or offer the players a choice.
 \begin{itemize}
-  \item \terrorism\ only affects players who have not yet researched \shields\ or \lasers\ (see \nameref{sec:disasters}, p.\pageref{sec:disasters}). The affected player must cross over two \population\ or gain one \unhappiness.
+  \item \pandemic\ only affects players who have not yet researched \cure\ (see \nameref{sec:disasters}, p.\pageref{sec:disasters}). The affected player must cross over two \population\ or gain one \unhappiness.
   \item The damages of \war\ can be negated by \deploying\ one \squadron.  The players who cannot or choose not to do this lose up to three \currency\ and gain one \unhappiness.
   \item \terrorism\ affects players whose \unhappiness\ (in terms of crossed boxes) is larger than their \happiness.  It can be prevented by \deploying\ one \squadron\ and gaining one \unhappiness.  Otherwise, a \fortification\ (the player chooses which) is destroyed and cannot be used for the rest of the game.  No new \fortifications\ may be built in the same space.  You may choose an opponent’s \battleship\ as the target, but they may prevent its destruction by deploying one \squadron.
 \end{itemize}

--- a/rules/rules_endgame.tex
+++ b/rules/rules_endgame.tex
@@ -1,5 +1,5 @@
 % !TEX TS-program = XeLaTeX
-The end of the game is triggered as soon as any player has completely filled any of their tracks (\population, \currency, any branch of the \tech\ track, \military, \trade, \culture) or constructed each \level\ III building type – i.e. whenever a \masterysymbol\ symbol is checked.
+The end of the game is triggered as soon as any player has completely filled any of their tracks (\population, \currency, any branch of the \tech\ track, \military, \trade, \culture) or constructed each \level\ III \fortification type – i.e. whenever a \masterysymbol\ symbol is checked.
 \newline\newline
 A player who foresees that they will end the game this way must announce it at the very beginning of that \development\ phase, and must then carry out this plan.  The only exception is when you trigger the end of the game by influencing an opponent’s sheet (e.g. if you complete a \convoy\ that causes the final box in their \culture\ grid to be checked).
 \newline\newline

--- a/rules/rules_fortifications2.tex
+++ b/rules/rules_fortifications2.tex
@@ -1,9 +1,9 @@
 % !TEX TS-program = XeLaTeX
-Example: The 3 \whitedice\ display values \texttt{2}, \texttt{3} and \texttt{4} and you have \texttt{1} \greatperson\ available.  If all three dice are used for construction, the total number possible is \texttt{2+3+4 = 9}.  This is enough to construct an \academy\ or \factory\ building, each of which cost 8 to complete.  The remainder (\texttt{9-8 = 1}) is lost, because no \fortifications\ cost \texttt{1}.  Alternatively, you could use only the \texttt{4} result and the \greatperson\ bonus of \texttt{+4}, sparing the \texttt{2} and \texttt{3} results for \activating\ \fortifications, \trade, or \culture.
+Example: The 3 \whitedice\ display values \texttt{2}, \texttt{3} and \texttt{4} and you have \texttt{1} \greatperson\ available.  If all three dice are used for construction, the total number possible is \texttt{2+3+4 = 9}.  This is enough to construct an \academy\ or \factory\ \fortification, each of which cost \texttt{8} to complete.  The remainder (\texttt{9-8 = 1}) is lost, because no \fortifications\ cost \texttt{1}.  Alternatively, you could use only the \texttt{4} result and the \greatperson\ bonus of \texttt{+4}, sparing the \texttt{2} and \texttt{3} results for \activating\ \fortifications, \trade, or \culture.
 \newline\newline
 There are six different \fortification\ types (see \nameref{sec:fortifications}, p.\pageref{sec:fortifications}) divided into three \levels.
 \begin{itemize}
-	\item To construct a \level\ II building, you need to have at least one staffed \fortification\ of each \level\ I type. Correspondingly, \level\ II \fortifications\ are a prerequisite for \level\ III \fortifications.
+	\item To construct a \level\ II \fortification, you need to have at least one staffed \fortification\ of each \level\ I type. Correspondingly, \level\ II \fortifications\ are a prerequisite for \level\ III \fortifications.
 	\item Constructing all \level\ III \fortifications\ triggers the end of the game and provides a scoring bonus.  Some rules always apply when constructing:
   \begin{itemize}
     \item Any number of \fortifications can be constructed on a turn

--- a/rules/rules_military.tex
+++ b/rules/rules_military.tex
@@ -3,7 +3,6 @@ The art of war is of vital importance to your \planet.  Mustering and deploying 
 \newline\newline
 \military\ units are produced by creating \starships.  Each time one of your \starships\ is \activated, you may cross off an \astronaut\ from your \population\ track (\gainastronautsymbol\ becoming \useastronautsymbol) and check the leftmost box of your \military\ track.  The boxes of the \military\ track are arranged in cohorts of two.  When a cohort is completely filled in, it becomes a \squadron.  Checking the final box triggers the end of the game and provides a scoring bonus.
 \newline\newline
-%TODO vars
 \squadrons\ can be deployed to various ends in the \deployment\ phase.  As you deploy a \squadron, you check the smaller box next to it (to show it has been used) and gain 1 point of \power\ (2 points instead if you are the defending or attacking side and have researched \shields\ or \lasers, respectively).  You may deploy several \squadrons\ at once.  As an attack is being resolved, players may deploy additional \squadrons.  Only after no one wishes to deploy any more \squadrons\ are the effects resolved.  \power\ is to be used instantly for \military\ actions: it does not carry over to the next turn.
 \newline\newline
 You may use 1 point of \power\ to defend against attacks:

--- a/rules/rules_playercount.tex
+++ b/rules/rules_playercount.tex
@@ -4,7 +4,7 @@ Theoretically, any number of players can join a game of \asciiplanets.  For prac
 In a solo game,
 \begin{itemize}
   \item You can still use \convoys\ and interact with \pirates.
-  \item Once all \pirates\ camps are destroyed, you may build exactly one \battleship\ to the \pirate's space following the normal rules (it does not take space on your map; just mark it on the sheet).  Upon activating it, you may \activate\ any \fortification\ type as if you had two more of that building.
+  \item Once all \pirates\ camps are destroyed, you may build exactly one \battleship\ to the \pirate's space following the normal rules (it does not take space on your map; just mark it on the sheet).  Upon activating it, you may \activate\ any \fortification\ type as if you had two more of that \fortification.
   \item The game ends after 20 turns. Other triggers do not cause the game to end (but you still get the \mastery\ bonuses).
 \end{itemize}
 In a two-player game,

--- a/rules/rules_population.tex
+++ b/rules/rules_population.tex
@@ -8,7 +8,7 @@ To leave your planet and venture into \outerspace, your \planet\ needs \astronau
 \end{itemize}
 Whenever one group of boxes of the \population\ track is completely filled in (\gainastronautsymbol), a \greatperson\ emerges.  You may at any time check the smaller box next to the group to:
 \begin{itemize}
-  \item Add \texttt{4} to the available dice available to spend for the purpose of building.
+  \item Add \texttt{4} to the available dice available to spend for the purpose of Construction.
   \item Check 2 boxes of the \tech\ track.
   \item Check any 2 boxes of the \culture\ grid.
 \end{itemize}

--- a/rules/rules_technology.tex
+++ b/rules/rules_technology.tex
@@ -4,7 +4,6 @@ The track branches at certain points: once past these, you may check boxes in an
 \newline\newline
 Various points on the track provide one-time or lasting benefits upon researching them (checking the indicated box).
 \begin{itemize}
-  %TODO Make these terms into vars
   \item \cure\ makes you immune to the \pandemic\ disaster.
   \item \antimatter\ (checking the first box of the upper shaded area) gives you access to the \bluedie\ for the rest of the game.
   \item \engineering\ research gives you access to the \blackdie\ for the rest of the game.


### PR DESCRIPTION
p7 rules: fixed up disasters to match planet sheet
fixed up symbols on the planet sheet for tech and gaining currency

Signed-off-by: Jacob Salmela <me@jacobsalmela.com>