### PR TITLE
Technology die description should be blue to match map and rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <strong>ASCII Planets</strong> is an spacefaring expansion to ASCII Empires (a "roll-and-write" board game of civilization building for 1-7 players)
+  <strong>ASCII Planets</strong> is a spacefaring expansion to ASCII Empires (a "roll-and-write" board game of civilization building for 1-7 players)
   <br>
   <img src="https://user-images.githubusercontent.com/3843505/94575720-26f6cf80-023a-11eb-9fdf-15091fc5c396.png" alt="ascii-planets-sheet">
 </p>

--- a/planet_sheet/technology.tex
+++ b/planet_sheet/technology.tex
@@ -13,7 +13,7 @@
   \multicolumn{1}{c}{} &
    &
    &
-  \multicolumn{9}{c}{\color{supplemental} Antimatter (Gain green die)} &
+  \multicolumn{9}{c}{\color{supplemental} Antimatter (Gain blue die)} &
    &
    &
    &


### PR DESCRIPTION
Correcting a few typos to test cross-fork PRs.